### PR TITLE
ci: add CI/CD pipeline for VS Code Marketplace publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
     steps:
       - name: Run Release Please
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add complete CI/CD pipeline using GitHub Actions
- Set up automated semantic versioning with release-please
- Enable automatic publishing to VS Code Marketplace

## Changes

- **ci.yml**: Lint and build on PRs + main pushes
- **release.yml**: Semantic versioning via release-please (conventional commits)
- **publish.yml**: Publish to VS Code Marketplace on release, upload VSIX artifact
- **release-please-config.json**: Changelog sections configuration
- **.release-please-manifest.json**: Version tracking (1.0.0)
- **.vscodeignore**: Exclude dev files from extension package
- **package.json**: Set publisher to `drewipson`, upgrade esbuild
- **Lint fixes**: Resolve all ESLint errors/warnings

## How It Works

1. **CI**: Runs lint + build on every PR and push to main
2. **Release**: When commits reach main, release-please creates a "Release PR":
   - `feat:` → minor bump
   - `fix:` → patch bump  
   - `feat!:` or `BREAKING CHANGE:` → major bump
3. **Publish**: When Release PR is merged → creates GitHub Release → publishes to Marketplace

## Prerequisites

Before first publish:
1. Create VS Code Marketplace publisher account
2. Create PAT at Azure DevOps with `Marketplace > Manage` scope
3. Add `VSCE_PAT` secret to GitHub repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)