### PR TITLE
ci: use gh CLI for releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,13 +73,13 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          files: claude-code-config.vsix
-          generate_release_notes: true
+        run: |
+          gh release create ${{ steps.version.outputs.version }} \
+            claude-code-config.vsix \
+            --title "${{ steps.version.outputs.version }}" \
+            --generate-notes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to VS Code Marketplace
         if: steps.check.outputs.exists == 'false'


### PR DESCRIPTION
## Summary

Replace `softprops/action-gh-release` with `gh release create` CLI command.

The action kept failing with permission errors. The gh CLI works better with GITHUB_TOKEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)