### PR TITLE
feat: add support for Claude Code rules folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
           "name": "Sub-Agents"
         },
         {
+          "id": "ccm.rules",
+          "name": "Rules"
+        },
+        {
           "id": "ccm.permissions",
           "name": "Permissions"
         },
@@ -213,6 +217,23 @@
         "command": "ccm.copyHookJson",
         "title": "Copy Hook JSON",
         "category": "Claude Code Config"
+      },
+      {
+        "command": "ccm.createRule",
+        "title": "Create Rule",
+        "icon": "$(add)",
+        "category": "Claude Code Config"
+      },
+      {
+        "command": "ccm.createRuleFolder",
+        "title": "Create Rule Folder",
+        "icon": "$(new-folder)",
+        "category": "Claude Code Config"
+      },
+      {
+        "command": "ccm.createRuleInFolder",
+        "title": "New Rule in Folder",
+        "category": "Claude Code Config"
       }
     ],
     "menus": {
@@ -256,6 +277,16 @@
           "command": "ccm.createHook",
           "when": "view == ccm.hooks",
           "group": "navigation@1"
+        },
+        {
+          "command": "ccm.createRule",
+          "when": "view == ccm.rules",
+          "group": "navigation@1"
+        },
+        {
+          "command": "ccm.createRuleFolder",
+          "when": "view == ccm.rules",
+          "group": "navigation@2"
         }
       ],
       "view/item/context": [
@@ -347,6 +378,11 @@
         {
           "command": "ccm.createSubAgentInFolder",
           "when": "viewItem == claudeFolder && view == ccm.subAgents",
+          "group": "create@1"
+        },
+        {
+          "command": "ccm.createRuleInFolder",
+          "when": "viewItem == claudeFolder && view == ccm.rules",
           "group": "create@1"
         },
         {

--- a/resources/templates/rule.md.template
+++ b/resources/templates/rule.md.template
@@ -1,0 +1,39 @@
+---
+description: Brief description of this rule
+paths: src/**/*.ts
+---
+
+# rule-name
+
+Rules are modular instructions that Claude follows when working on matching files.
+Path targeting (in frontmatter above) ensures this rule only applies when working on files matching the pattern.
+
+## When to Apply
+
+This rule applies when:
+- Working with files matching the `paths` pattern above
+- [Add specific conditions]
+
+## Guidelines
+
+1. [First guideline]
+2. [Second guideline]
+3. [Third guideline]
+
+## Examples
+
+Good:
+```
+[Example of correct behavior]
+```
+
+Avoid:
+```
+[Example of what to avoid]
+```
+
+## Notes
+
+- Rules without `paths` frontmatter apply to all files
+- Use glob patterns: `src/**/*.ts`, `*.test.js`, `api/**/*`
+- Rules are project-specific (stored in .claude/rules/)

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -13,6 +13,7 @@ export const CLAUDE_MD_PATTERNS = ['CLAUDE.md', 'claude.md'];
 export const SKILLS_DIR = 'skills';
 export const AGENTS_DIR = 'agents';
 export const COMMANDS_DIR = 'commands';
+export const RULES_DIR = 'rules';
 
 // File extensions
 export const MARKDOWN_EXTENSIONS = ['.md', '.markdown'];
@@ -24,6 +25,7 @@ export const VIEW_IDS = {
   commands: 'ccm.commands',
   skills: 'ccm.skills',
   subAgents: 'ccm.subAgents',
+  rules: 'ccm.rules',
   permissions: 'ccm.permissions',
   hooks: 'ccm.hooks',
   documentation: 'ccm.documentation',
@@ -57,6 +59,9 @@ export const COMMAND_IDS = {
   deleteHook: 'ccm.deleteHook',
   duplicateHook: 'ccm.duplicateHook',
   copyHookJson: 'ccm.copyHookJson',
+  createRule: 'ccm.createRule',
+  createRuleFolder: 'ccm.createRuleFolder',
+  createRuleInFolder: 'ccm.createRuleInFolder',
 };
 
 // Documentation links
@@ -72,6 +77,12 @@ export const DOCUMENTATION_LINKS: DocumentationLink[] = [
     url: 'https://code.claude.com/docs/en/memory',
     description: 'Writing effective CLAUDE.md files',
     icon: 'file-text',
+  },
+  {
+    title: 'Rules',
+    url: 'https://code.claude.com/docs/en/memory#rules',
+    description: 'Modular rules with path targeting',
+    icon: 'law',
   },
   {
     title: 'Sub-Agents',
@@ -94,6 +105,7 @@ export const ICONS = {
   command: 'terminal',
   skill: 'lightbulb',
   subAgent: 'robot',
+  rule: 'law',
   permission: 'shield',
   settings: 'gear',
   folder: 'folder',

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -11,6 +11,7 @@ export interface ClaudeFile {
   isDirectory?: boolean;
   parentType?: ClaudeFileType; // For folders, indicates what type of files they contain
   color?: string; // For sub-agents, optional color from YAML frontmatter
+  paths?: string; // For rules, optional path targeting from YAML frontmatter
 }
 
 export type ClaudeFileType =
@@ -18,6 +19,7 @@ export type ClaudeFileType =
   | 'command'      // Slash command files
   | 'skill'        // Skill files (SKILL.md)
   | 'subAgent'     // Sub-agent files
+  | 'rule'         // Rule files (.claude/rules/)
   | 'permission'   // Permission files
   | 'settings';    // Settings files
 

--- a/src/services/fileOperationsService.ts
+++ b/src/services/fileOperationsService.ts
@@ -7,6 +7,7 @@ import {
   COMMANDS_DIR,
   SKILLS_DIR,
   AGENTS_DIR,
+  RULES_DIR,
 } from '../core/constants';
 
 export class FileOperationsService {
@@ -146,6 +147,7 @@ export class FileOperationsService {
       command: COMMANDS_DIR,
       skill: SKILLS_DIR,
       subAgent: AGENTS_DIR,
+      rule: RULES_DIR,
     };
 
     const subDir = dirMap[fileType];
@@ -247,11 +249,11 @@ export class FileOperationsService {
         // Delete single file
         await fs.promises.unlink(claudeFile.path);
 
-        // If the parent directory is empty and it's in skills/agents/commands, delete it too
+        // If the parent directory is empty and it's in skills/agents/commands/rules, delete it too
         const parentDir = path.dirname(claudeFile.path);
         const parentDirName = path.basename(path.dirname(parentDir));
 
-        if (['skills', 'agents', 'commands'].includes(parentDirName)) {
+        if (['skills', 'agents', 'commands', 'rules'].includes(parentDirName)) {
           try {
             const filesInParent = await fs.promises.readdir(parentDir);
             if (filesInParent.length === 0) {


### PR DESCRIPTION
Hey there!

Thank you for the awesome extension! Really enjoy using it.
I noticed that it's missing rules currently which was introduced a while ago to Claude Code so I added those.

I also noticed that in some places you have Global/Project categories but for some you don't so I thought to unify this and always put the md files under Global/Project to make things clear and avoid having [Project] everywhere needlessly.

Let me know if you want me to make any changes to the PR before merging and I'd be happy to modify.
I also gave you edit access so feel free to modify the code as you see fit before merging.

All the best

---

Screenshots of the changes:

<img width="2218" height="1683" alt="2025-12-25_Code - Insiders_01-13-22" src="https://github.com/user-attachments/assets/11a5196c-3f1e-409e-ab2a-7874978126e5" />

---

## AI Summary (The text below is generated by Claude Opus but might be useful as it gives more details)

Add full support for the new `.claude/rules/` directory feature introduced in Claude Code v2.0.64. Rules are modular markdown files that provide domain-specific instructions with optional path targeting via YAML frontmatter.

## New Features

### Rules View
- New "Rules" section in the sidebar for managing rule files
- Discovers rules from both global (`~/.claude/rules/`) and project (`.claude/rules/`)
- Displays path targeting patterns in item description (e.g., `[src/**/*.ts]`)
- Supports folder organization within rules directory
- Shows markdown sections when expanded for easy navigation

### Create Rule Commands
- **Create Rule** - creates new rule with scope selection (Global/Project)
- **Create Rule Folder** - organizes rules in subdirectories  
- **Create Rule in Folder** - adds rules directly to existing folders

### Rule Template
- New `rule.md.template` with YAML frontmatter example for path targeting
- Includes documentation on when rules apply and best practices

## UI Improvements

### Consistent Global/Project Grouping
All tree views now display consistent header groups for better organization:

| View | Grouping |
|------|----------|
| Memories | Global, Project, Nested sections with counts |
| Commands | Global and Project headers with path descriptions |
| Skills | Global and Project headers with path descriptions |
| Sub-Agents | Global and Project headers with path descriptions |
| Rules | Global and Project headers with path descriptions |
| Hooks | Global and Project headers with settings file paths |

Each header shows:
- 🏠 Home icon for Global scope with `~/.claude` path
- 📁 Folder icon for Project scope with `.claude` path
- Item count in parentheses

### Cleaner Item Display
- Removed redundant `[Project]`/`[Global]` tags from individual items
- Scope is now clear from the parent header grouping

## Screenshots

The new Rules view follows the same pattern as other views:

```
Rules
├── Global (2)           ~/.claude/rules
 │    ── typescript-best-practices
 │    ── general-programming
└── Project (1)          .claude/rules
    └── api-validation      [src/api/**/*.ts]
```

## Technical Changes

- Added `rule` to `ClaudeFileType` union type
- Added `paths` property to `ClaudeFile` for path targeting
- Added `RULES_DIR` constant and related command/view IDs
- New `discoverRules()` method in FileDiscoveryService
- New `RulesTreeProvider` class for rules tree view
- Updated `FileOperationsService` to handle rule file type
- Registered 3 new commands in extension.ts
- Added rules view and menu items in package.json

## Test Plan

- [ ] Verify rules are discovered from `~/.claude/rules/`
- [ ] Verify rules are discovered from `.claude/rules/`
- [ ] Create new rule in Global scope
- [ ] Create new rule in Project scope
- [ ] Create rule folder and add rules to it
- [ ] Verify path targeting displays correctly
- [ ] Verify all other views (Memories, Commands, Skills, Sub-Agents, Hooks) show proper Global/Project grouping